### PR TITLE
Add check for number of peers

### DIFF
--- a/packages/protocol-plugin-replicator/src/replicator.test.js
+++ b/packages/protocol-plugin-replicator/src/replicator.test.js
@@ -87,6 +87,7 @@ describe('test data replication in a balanced network graph of 15 peers', () => 
       topic,
       parameters: [1]
     });
+    expect(network.peers.length).toBe(15);
   });
 
   test('feed synchronization', async () => {


### PR DESCRIPTION
Noticed this in passing : the test description says 15 peers but actually creates 3 (binary tree with 1 non-root level).